### PR TITLE
Remove Requires 'ansible' in .spec

### DIFF
--- a/ssm-server.spec
+++ b/ssm-server.spec
@@ -15,7 +15,7 @@ License:	AGPLv3
 URL:		https://%{provider_prefix}
 Source0:	%{name}-%{version}.tar.gz
 
-Requires:	nginx ansible git bats
+Requires:	nginx git bats
 BuildRequires:	openssl nodejs npm
 
 %if 0%{?fedora} || 0%{?rhel} == 7


### PR DESCRIPTION
`ansible` was required because of the 'Auto Upgrade' feature, since we decided to remove that feature and `ansible` has been deprecated in 8.7, we don't need it anymore.