### PR TITLE
Fix upgrade process

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,13 +97,12 @@ migrate_from_pmm() {
     local supervisord_pid=
     supervisord -n -c /etc/supervisord.conf & supervisord_pid=$!
 
-    # Stop all running services
-    while read -r line; do
-        line_arr=(${line})
-        if [[ "${line_arr[1]}" == "RUNNING" ]] && [[ "${line_arr[0]}" != "mysql" ]]; then
-            supervisorctl stop "${line_arr[0]}"
-        fi
-    done < <(supervisorctl status)
+    # Stop all running services and start mysqld only
+    supervisorctl stop all
+    supervisorctl start mysql
+
+    # Wait for mysql to start
+    sleep 5
 
     # Migrate mysql to mariadb
     mysql_upgrade

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,7 +74,7 @@ pushd /etc/nginx >/dev/null
 popd >/dev/null
 
 # Upgrade
-if [ -f /opt/consul-data/node-id ]; then
+if [ -f /var/lib/grafana/PERCONA_DASHBOARDS_VERSION ] && [ -f /usr/share/ssm-dashboards/VERSION ] && [[ "$(cat /usr/share/ssm-dashboards/VERSION)" > "$(cat /var/lib/grafana/PERCONA_DASHBOARDS_VERSION)" ]]; then
     # Check if it's a upgrade from PMM
     if [[ $(stat -c "%U" /opt/prometheus/data) == "pmm" ]]; then
         migrate_from_pmm
@@ -84,9 +84,6 @@ if [ -f /opt/consul-data/node-id ]; then
     chown -R ssm:ssm /opt/prometheus/data
     chown -R mysql:mysql /var/lib/mysql
     chown -R grafana:grafana /var/lib/grafana
-
-    # Do not set the innodb_page_size if it's an upgrade
-    sed -i "s/^\([[:space:]]*innodb_page_size.*\)/#\1/g" /etc/my.cnf.d/00-ssm.cnf
 fi
 
 cat /tmp/ssm.ini > /etc/supervisord.d/ssm.ini

--- a/my.cnf
+++ b/my.cnf
@@ -10,7 +10,6 @@
   innodb_buffer_pool_load_at_startup = OFF
   innodb_compression_algorithm = lz4
   innodb_flush_neighbors = 0
-  innodb_page_size = 64K
 
 # Disable Query Cache by default
   query_cache_size=0

--- a/page.cnf
+++ b/page.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+  innodb_page_size = 64K

--- a/ssm-server.spec
+++ b/ssm-server.spec
@@ -66,6 +66,7 @@ mv clickhouse.xml %{buildroot}%{_sysconfdir}/clickhouse-server/config.xml
 
 install -d %{buildroot}%{_sysconfdir}/my.cnf.d
 mv my.cnf %{buildroot}%{_sysconfdir}/my.cnf.d/00-ssm.cnf
+mv page.cnf %{buildroot}%{_sysconfdir}/my.cnf.d/page.cnf
 
 install -d %{buildroot}%{_sysconfdir}/supervisord.d
 mv supervisord.conf %{buildroot}%{_sysconfdir}/supervisord.d/ssm.ini


### PR DESCRIPTION
The process of preparing the `page.cnf` file is defined in ssm-submodules -> https://github.com/shatteredsilicon/ssm-submodules/pull/106/files#diff-cb6b89664d2df89413300593297b6ff7f731a233b9a5901c73d6c2f2682d18d5R46-R47