### PR TITLE
Revert "Set working directory of prometheus to /usr/share/prometheus"

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -118,7 +118,6 @@ command =
         --web.enable-admin-api
         --web.enable-lifecycle
         --web.enable-remote-write-receiver
-directory = /usr/share/prometheus
 environment = GOGC=50
 stdout_logfile = /var/log/prometheus.log
 stderr_logfile = /var/log/prometheus.log


### PR DESCRIPTION
Revert it as those web ui assets are embeded into the prometheus binary, we don't need to set working directory to find the external web ui assets anymore.

Reverts shatteredsilicon/ssm-server#48