### PR TITLE
Set startsecs=0 to adjust-mariadb svc to fix 'Exited too quickly' error

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -17,6 +17,7 @@ user = root
 [program:adjust-mariadb]
 priority = 1
 command = bash -c "[ -z \"${ON_SSM_SERVER_SETUP}\" ] && [ \"$(stat -L -f -c '%%T' /var/lib/mysql)\" == \"zfs\" ] && sed -i \"/^\\s*innodb_flush_log_at_trx_commit/ s/^/\#/\" /etc/my.cnf.d/00-ssm.cnf || true"
+startsecs = 0
 stdout_logfile = /var/log/adjust-mariadb.log
 stderr_logfile = /var/log/adjust-mariadb.log
 


### PR DESCRIPTION
Close https://github.com/shatteredsilicon/ssm-submodules/issues/410