### PR TITLE
Bump minimum TLS from 1.0 to 1.2 (RFC 8996)

### DIFF
--- a/nginx-ssl.conf
+++ b/nginx-ssl.conf
@@ -1,4 +1,4 @@
-ssl_protocols			TLSv1 TLSv1.1 TLSv1.2;
+ssl_protocols			TLSv1.2 TLSv1.3;
 ssl_prefer_server_ciphers	on;
 ssl_ciphers			"EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
 ssl_ecdh_curve			secp384r1;


### PR DESCRIPTION
Bumps minimum TLS version from 1.0 to 1.2. TLS 1.0 and 1.1 are deprecated per RFC 8996 (March 2021).

See: https://www.rfc-editor.org/rfc/rfc8996

Related issue: https://github.com/shatteredsilicon/ssm-submodules/issues/497